### PR TITLE
bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     env:
       CI_SCALA_VERSION: ${{matrix.scala}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: coursier/cache-action@v6
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{matrix.java}}


### PR DESCRIPTION
I don't expect any relevant behavior differences, but GitHub was complaining ("The following actions uses node12 which is deprecated and will be forced to run on node16")
