### PR TITLE
Update scalafix to 0.11.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release" % "1.5.12")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.10.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.11.0")

--- a/rewrites/src/main/scala/fix/scala213/Any2StringAdd.scala
+++ b/rewrites/src/main/scala/fix/scala213/Any2StringAdd.scala
@@ -22,8 +22,8 @@ final class Any2StringAdd extends SemanticRule("fix.scala213.Any2StringAdd") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case any2stringaddPlusString(Term.ApplyInfix(lhs, _, _, _)) => wrapStringValueOf(lhs)
-      case primitivePlusString(Term.ApplyInfix(lhs, _, _, _)) => blankStringPlus(lhs)
+      case any2stringaddPlusString(Term.ApplyInfix.Initial(lhs, _, _, _)) => wrapStringValueOf(lhs)
+      case primitivePlusString(Term.ApplyInfix.Initial(lhs, _, _, _)) => blankStringPlus(lhs)
     }.asPatch
   }
 

--- a/rewrites/src/main/scala/fix/scala213/Core.scala
+++ b/rewrites/src/main/scala/fix/scala213/Core.scala
@@ -20,24 +20,24 @@ final class Core extends SemanticRule("fix.scala213.Core") {
 
     val platformArraycopy: Replacer = {
       case arraycopy(i: Importee)      => Patch.removeImportee(i)
-      case arraycopy(Term.Apply(t, _)) => replaceTree(t, "System.arraycopy")
+      case arraycopy(Term.Apply.Initial(t, _)) => replaceTree(t, "System.arraycopy")
     }
 
     val consoleRead: Replacer = {
-      case deprecatedConsoleReadBoolean(Term.Apply(t, _)) => stdInReplace(t, "readBoolean")
-      case deprecatedConsoleReadByte(   Term.Apply(t, _)) => stdInReplace(t, "readByte")
-      case deprecatedConsoleReadChar(   Term.Apply(t, _)) => stdInReplace(t, "readChar")
-      case deprecatedConsoleReadDouble( Term.Apply(t, _)) => stdInReplace(t, "readDouble")
-      case deprecatedConsoleReadFloat(  Term.Apply(t, _)) => stdInReplace(t, "readFloat")
-      case deprecatedConsoleReadInt(    Term.Apply(t, _)) => stdInReplace(t, "readInt")
-      case deprecatedConsoleReadLine(   Term.Apply(t, _)) => stdInReplace(t, "readLine")
-      case deprecatedConsoleReadLine1(  Term.Apply(t, _)) => stdInReplace(t, "readLine")
-      case deprecatedConsoleReadLong(   Term.Apply(t, _)) => stdInReplace(t, "readLong")
-      case deprecatedConsoleReadShort(  Term.Apply(t, _)) => stdInReplace(t, "readShort")
-      case deprecatedConsoleReadf(      Term.Apply(t, _)) => stdInReplace(t, "readf")
-      case deprecatedConsoleReadf1(     Term.Apply(t, _)) => stdInReplace(t, "readf1")
-      case deprecatedConsoleReadf2(     Term.Apply(t, _)) => stdInReplace(t, "readf2")
-      case deprecatedConsoleReadf3(     Term.Apply(t, _)) => stdInReplace(t, "readf3")
+      case deprecatedConsoleReadBoolean(Term.Apply.Initial(t, _)) => stdInReplace(t, "readBoolean")
+      case deprecatedConsoleReadByte(   Term.Apply.Initial(t, _)) => stdInReplace(t, "readByte")
+      case deprecatedConsoleReadChar(   Term.Apply.Initial(t, _)) => stdInReplace(t, "readChar")
+      case deprecatedConsoleReadDouble( Term.Apply.Initial(t, _)) => stdInReplace(t, "readDouble")
+      case deprecatedConsoleReadFloat(  Term.Apply.Initial(t, _)) => stdInReplace(t, "readFloat")
+      case deprecatedConsoleReadInt(    Term.Apply.Initial(t, _)) => stdInReplace(t, "readInt")
+      case deprecatedConsoleReadLine(   Term.Apply.Initial(t, _)) => stdInReplace(t, "readLine")
+      case deprecatedConsoleReadLine1(  Term.Apply.Initial(t, _)) => stdInReplace(t, "readLine")
+      case deprecatedConsoleReadLong(   Term.Apply.Initial(t, _)) => stdInReplace(t, "readLong")
+      case deprecatedConsoleReadShort(  Term.Apply.Initial(t, _)) => stdInReplace(t, "readShort")
+      case deprecatedConsoleReadf(      Term.Apply.Initial(t, _)) => stdInReplace(t, "readf")
+      case deprecatedConsoleReadf1(     Term.Apply.Initial(t, _)) => stdInReplace(t, "readf1")
+      case deprecatedConsoleReadf2(     Term.Apply.Initial(t, _)) => stdInReplace(t, "readf2")
+      case deprecatedConsoleReadf3(     Term.Apply.Initial(t, _)) => stdInReplace(t, "readf3")
     }
 
     private def stdInReplace(tree: Tree, name: String): Patch =

--- a/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -59,7 +59,7 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
         if handled.add(name)
         if noArgs
         if name.isReference
-        if !cond(name.parent) { case Some(Term.ApplyInfix(_, `name`, _, _)) => true }
+        if !cond(name.parent) { case Some(Term.ApplyInfix.Initial(_, `name`, _, _)) => true }
         if !tree.parent.exists(_.is[Term.Eta]) // else rewrites `meth _` to `meth() _`, or requires running ExplicitNullaryEtaExpansion first
         // HACK: In certain cases, `Symbol.info` may throw `MissingSymbolException` due to some unknown reason
         // If it happens, here we assume that this symbol has no info

--- a/rewrites/src/main/scala/fix/scala213/NullaryHashHash.scala
+++ b/rewrites/src/main/scala/fix/scala213/NullaryHashHash.scala
@@ -9,7 +9,7 @@ final class NullaryHashHash extends SemanticRule("fix.scala213.NullaryHashHash")
 
   override def fix(implicit doc: SemanticDocument) = {
     doc.tree.collect {
-      case expr @ Term.Apply(HashHash(fun), Nil) =>
+      case expr @ Term.Apply.Initial(HashHash(fun), Nil) =>
         Patch.removeTokens(expr.tokens.takeRight(expr.pos.end - fun.pos.end))
     }.asPatch
   }

--- a/rewrites/src/main/scala/fix/scala213/ScalaSeq.scala
+++ b/rewrites/src/main/scala/fix/scala213/ScalaSeq.scala
@@ -34,7 +34,7 @@ final class ScalaSeq(val config: ScalaSeq.Config) extends SemanticRule("fix.scal
         inParam = false
         apply(p.default)
 
-      case scalaSeq(Type.Apply(t, _)) =>
+      case scalaSeq(Type.Apply.Initial(t, _)) =>
         val sub = if (inParam) {
           paramImport.foreach(i => patch += globalImports.add(i))
           config.paramType

--- a/tests/src/test/scala/fix/RuleSuite.scala
+++ b/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,10 +1,11 @@
 package fix
 
 import scala.reflect.ensureAccessible
-import org.scalatest.{ ConfigMap, FunSpecLike }
+import org.scalatest.ConfigMap
+import org.scalatest.funspec.AnyFunSpecLike
 import scalafix.testkit.AbstractSemanticRuleSuite
 
-class RuleSuite extends AbstractSemanticRuleSuite with FunSpecLike with BeforeAndAfterAllConfigMapAlt {
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSpecLike with BeforeAndAfterAllConfigMapAlt {
   val isSaveExpectField = ensureAccessible(classOf[AbstractSemanticRuleSuite].getDeclaredField("isSaveExpect"))
 
   // If you invoke the test as "tests/testOnly -- -Doverwrite=true" it will save the expected


### PR DESCRIPTION
This PR updates scalafix to 0.11.0 with following changes:

* Address scalatest trait changes (scalafix 0.11.0 also updates scalatest to 3.2.x)
  * https://www.scalatest.org/release_notes/3.2.0
* Remove use of deprecated unversioned matchers
  * https://github.com/scalameta/scalameta/releases/tag/v4.7.4
  * https://scalameta.org/docs/trees/guide.html#with-versioned-constructor-like-matchers

closes https://github.com/lightbend-labs/scala-rewrites/pull/181